### PR TITLE
TTLCache cleanup and extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,18 @@ See [TTLCache.Server](lib/ttl_cache/server.ex) for the latest documentation
 
 {:ok, nil} = TTLCache.Server.get(pid, :hello)
 ```
+
+### Refresh Strategies
+
+`TTLCache.Server` supports several refresh strategies:
+
+* `:on_write` - refresh the TTL when the key is written to. Does not care whether or not the value changed
+* `:on_read` - refresh the TTL when the key is read. Note that any update (including `get_and_update`) is considered a write
+* `:on_read_write` - refresh the TTL when the key is written to or read
+* `:never` - never refresh and just remove the key after the TTL
+
+You can pass these strategies via `TTLCache.Server.start_link`:
+
+```ex
+TTLCache.Server.start_link(refresh_strategy: :on_write)
+```

--- a/lib/ttl_cache/expiration.ex
+++ b/lib/ttl_cache/expiration.ex
@@ -1,0 +1,61 @@
+defmodule TTLCache.Expiration do
+  @callback init(state :: map) :: state :: map
+  @callback on_write(state :: map, {key :: term, value :: term}) :: state :: map
+  @callback on_read(state :: map, key :: term) :: state :: map
+  @callback on_delete(state :: map, key :: term) :: state :: map
+  @callback expire?(state :: map, {key :: term, metadata :: term}) :: true | false
+end
+
+defmodule TTLCache.Expiration.SendAfter do
+  @moduledoc """
+  Callback module for implementing key expiration via Process.send_after. This approach
+  works by using the BEAM's internal scheduling expire keys. Process.send_after will
+  wait for some period of time and then send a message to the cache server. The cache
+  server is configured to handle :expire messages and will delegate back to this module
+  which will ensure that we're properly filtering out irrelevant expire messages (i.e.
+  when we "refresh" the expiration we are just incrementing a pointer/watermark and we
+  ignore any previous messages)
+  """
+
+  @behaviour TTLCache.Expiration
+
+  def init(state) do
+    put_in(state[:watermarks], %{})
+  end
+
+  def on_write(state = %{refresh_strategy: strat}, {key, _val}) when strat == :on_write or strat == :on_read_write do
+    new_watermark = Map.get(state[:watermarks], key, -1) + 1
+    Process.send_after(self(), {:expire, {key, new_watermark}}, state.ttl)
+    put_in(state[:watermarks][key], new_watermark)
+  end
+
+  def on_write(state, {key, _val}) do
+    if key not in Map.keys(state.entries) do
+      Process.send_after(self(), {:expire, {key, nil}}, state.ttl)
+    end
+
+    state
+  end
+
+  def on_read(state = %{refresh_strategy: strat}, key) when strat == :on_read or strat == :on_read_write do
+    new_watermark = Map.get(state[:watermarks], key, -1) + 1
+    Process.send_after(self(), {:expire, {key, new_watermark}}, state.ttl)
+    put_in(state[:watermarks][key], new_watermark)
+  end
+
+  def on_read(state, _) do
+    state
+  end
+
+  def expire?(state, {key, watermark}) do
+    if state.refresh_strategy != :never do
+      Map.has_key?(state.entries, key) && watermark == get_in(state, [:watermarks, key])
+    else
+      Map.has_key?(state.entries, key)
+    end
+  end
+
+  def on_delete(state, key) do
+    update_in(state[:watermarks], &Map.delete(&1, key))
+  end
+end

--- a/test/ttl_cache_test.exs
+++ b/test/ttl_cache_test.exs
@@ -1,45 +1,46 @@
 defmodule TTLCacheTest do
   use ExUnit.Case
   doctest TTLCache
+  alias TTLCache.Server
 
   describe "TTLCache.Server.put/1" do
     test "puts the item to the server under the given key" do
-      {:ok, pid} = TTLCache.Server.start_link(ttl: 1000)
-      :ok = TTLCache.Server.put(pid, :hello, :world)
-      assert TTLCache.Server.get(pid, :hello) == :world
+      {:ok, pid} = Server.start_link(ttl: 1000)
+      :ok = Server.put(pid, :hello, :world)
+      assert Server.get(pid, :hello) == :world
     end
 
     test "can overwrite values" do
-      {:ok, pid} = TTLCache.Server.start_link(ttl: 1000)
-      :ok = TTLCache.Server.put(pid, :hello, :world)
-      :ok = TTLCache.Server.put(pid, :hello, :everyone)
-      assert TTLCache.Server.get(pid, :hello) == :everyone
+      {:ok, pid} = Server.start_link(ttl: 1000)
+      :ok = Server.put(pid, :hello, :world)
+      :ok = Server.put(pid, :hello, :everyone)
+      assert Server.get(pid, :hello) == :everyone
     end
 
     test "expires after the ttl" do
       ttl = 500
-      {:ok, pid} = TTLCache.Server.start_link(ttl: ttl)
-      :ok = TTLCache.Server.put(pid, :hello, :world)
+      {:ok, pid} = Server.start_link(ttl: ttl)
+      :ok = Server.put(pid, :hello, :world)
       :timer.sleep(1000)
-      assert TTLCache.Server.get(pid, :hello) == nil
+      assert Server.get(pid, :hello) == nil
     end
 
     test "with refresh_strategy = :on_write, refreshes the TTL" do
       ttl = 500
-      {:ok, pid} = TTLCache.Server.start_link(ttl: ttl, refresh_strategy: :on_write)
-      :ok = TTLCache.Server.put(pid, :hello, :world)
+      {:ok, pid} = Server.start_link(ttl: ttl, refresh_strategy: :on_write)
+      :ok = Server.put(pid, :hello, :world)
 
       # Sleep for half of the TTL then update (elapsed = ttl / 2)
       :timer.sleep(round(ttl / 2))
-      :ok = TTLCache.Server.put(pid, :hello, :mom)
+      :ok = Server.put(pid, :hello, :mom)
 
       # Wake up after the original expire would have happened (elapsed = (7/6) * ttl)
       :timer.sleep(round(ttl * 2 / 3))
-      assert TTLCache.Server.get(pid, :hello) == :mom
+      assert Server.get(pid, :hello) == :mom
 
       # Wake up after the updated expire should have happened (elapsed > 2 * ttl)
       :timer.sleep(ttl)
-      assert TTLCache.Server.get(pid, :hello) == nil
+      assert Server.get(pid, :hello) == nil
     end
   end
 
@@ -47,22 +48,22 @@ defmodule TTLCacheTest do
     test "yields the value that is being expired" do
       myself = self()
       callback = fn value -> send(myself, value) end
-      {:ok, pid} = TTLCache.Server.start_link(ttl: 500, on_expire: callback)
-      :ok = TTLCache.Server.put(pid, :hello, :world)
+      {:ok, pid} = Server.start_link(ttl: 500, on_expire: callback)
+      :ok = Server.put(pid, :hello, :world)
       assert_receive {:hello, :world}, 1000
     end
   end
 
-  describe "TTLCache.Server.entries/1" do
+  describe "entries/1" do
     test "returns a map of the entries" do
-      {:ok, pid} = TTLCache.Server.start_link(ttl: 1000)
-      :ok = TTLCache.Server.put(pid, :hello, :world)
-      :ok = TTLCache.Server.put(pid, :elixir, :is_cool)
-      assert TTLCache.Server.entries(pid) == %{hello: :world, elixir: :is_cool}
+      {:ok, pid} = Server.start_link(ttl: 1000)
+      :ok = Server.put(pid, :hello, :world)
+      :ok = Server.put(pid, :elixir, :is_cool)
+      assert Server.entries(pid) == %{hello: :world, elixir: :is_cool}
     end
   end
 
-  describe "TTLCache.Server.keys/1" do
+  describe "keys/1" do
     test "returns all the keys" do
       {:ok, pid} = TTLCache.Server.start_link(ttl: 1000)
       :ok = TTLCache.Server.put(pid, :hello, :world)
@@ -73,7 +74,7 @@ defmodule TTLCacheTest do
     end
   end
 
-  describe "TTLCache.Server.values/1" do
+  describe "values/1" do
     test "returns all the values" do
       {:ok, pid} = TTLCache.Server.start_link(ttl: 1000)
       :ok = TTLCache.Server.put(pid, :hello, :world)
@@ -84,28 +85,75 @@ defmodule TTLCacheTest do
     end
   end
 
-  describe "TTLCache.Server.delete/1" do
+  describe "delete/1" do
     test "deletes the entry" do
-      {:ok, pid} = TTLCache.Server.start_link(ttl: 1000)
-      :ok = TTLCache.Server.put(pid, :hello, :world)
-      :ok = TTLCache.Server.delete(pid, :hello)
-      assert TTLCache.Server.get(pid, :hello) == nil
+      {:ok, pid} = Server.start_link(ttl: 1000)
+      :ok = Server.put(pid, :hello, :world)
+      :ok = Server.delete(pid, :hello)
+      assert Server.get(pid, :hello) == nil
     end
 
     test "doesn't call the expire callback" do
       parent = self()
-      {:ok, pid} = TTLCache.Server.start_link(ttl: 1000, on_expire: fn _ -> send(parent, :yo) end)
-      :ok = TTLCache.Server.put(pid, :hello, :world)
-      :ok = TTLCache.Server.delete(pid, :hello)
+      {:ok, pid} = Server.start_link(ttl: 1000, on_expire: fn _ -> send(parent, :yo) end)
+      :ok = Server.put(pid, :hello, :world)
+      :ok = Server.delete(pid, :hello)
       refute_received :yo, 1_000
     end
   end
 
-  describe "TTLCache.Server.init/1" do
+  describe "init/1" do
     test "raises if invalid refresh_strategy" do
       assert_raise ArgumentError, fn ->
-        TTLCache.Server.init(%{refresh_strategy: :bad_strat})
+        Server.init(%{refresh_strategy: :bad_strat})
       end
+    end
+  end
+
+  describe "never refresh strategy" do
+    test "doesn't refresh on get()" do
+      {:ok, pid} = Server.start_link(ttl: 500, refresh_strategy: :never)
+      :ok = Server.put(pid, :hello, :world)
+      Process.sleep(250)
+      assert :world == Server.get(pid, :hello)
+      Process.sleep(250)
+      assert nil == Server.get(pid, :hello)
+    end
+
+    test "doesn't refresh on get_and_update()" do
+      {:ok, pid} = Server.start_link(ttl: 500, refresh_strategy: :never)
+      :ok = Server.put(pid, :hello, :world)
+      Process.sleep(250)
+      assert :world == Server.get_and_update(pid, :hello, &{&1, :mom})
+      Process.sleep(250)
+      assert nil == Server.get(pid, :hello)
+    end
+
+    test "doesn't refresh on put()" do
+      {:ok, pid} = Server.start_link(ttl: 500, refresh_strategy: :never)
+      :ok = Server.put(pid, :hello, :world)
+      Process.sleep(250)
+      assert :ok == Server.put(pid, :hello, :mom)
+      Process.sleep(250)
+      assert nil == Server.get(pid, :hello)
+    end
+
+    test "doesn't refresh on update()" do
+      {:ok, pid} = Server.start_link(ttl: 500, refresh_strategy: :never)
+      :ok = Server.put(pid, :hello, :world)
+      Process.sleep(250)
+      assert :ok == Server.update(pid, :hello, &{&1, :mom})
+      Process.sleep(250)
+      assert nil == Server.get(pid, :hello)
+    end
+
+    test "doesn't refresh on entries()" do
+      {:ok, pid} = Server.start_link(ttl: 500, refresh_strategy: :never)
+      :ok = Server.put(pid, :hello, :world)
+      Process.sleep(250)
+      assert %{hello: :world} == Server.entries(pid)
+      Process.sleep(250)
+      assert nil == Server.get(pid, :hello)
     end
   end
 end


### PR DESCRIPTION
There are a couple of things going on in this PR:

* Move functions around and add stronger documentation
* Add tests for each refresh strategy
* Add two more refresh strategies (`:on_read`, `:on_read_write`)
* Set ourselves up for replacing the expiration strategy. This sets us up to tackle https://github.com/wistia/ttl_cache/issues/1